### PR TITLE
update jeopardy board so that visited questions are no longer shown

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,11 +46,10 @@ def host_setup():
                 increments.append(val)
                 que_str = "c"+ str(i+1) + "-" + str(val)
                 ans_str = "nm" + str(i+1) + "-" + str(val)
-                jeop_board[val] = [request.form.get(que_str), request.form.get(ans_str)]
+                jeop_board[val] = [request.form.get(que_str), request.form.get(ans_str), 1]
             master.append(jeop_board)
                 #questions.append(request.form.get(que_str))
                 #answers.append(request.form.get(ans_str))
-        print(master)
         increments = list(range(start_amount, stop_amount, increment))
         session['jeopardy'] = master
         session['categories'] = categories
@@ -62,15 +61,22 @@ def host_setup():
 @app.route("/jeopardy_board", methods=['GET', 'POST'])
 def jeopardy_form_post():
     return render_template("jeo_board.html", categories=session['categories'], \
-            increments=session['increments'])
+            increments=session['increments'], board=session['jeopardy'])
 
 
 
 @app.route("/answer_page/<category>/<value>")
 def answer_page(category, value):
     category = int(category)
-    question = session['jeopardy'][category][value][0]
-    answer = session['jeopardy'][category][value][1]
+    
+    # Pop out and update the board
+    jeopardy_board = session.pop('jeopardy')
+    question = jeopardy_board[category][value][0]
+    answer = jeopardy_board[category][value][1]
+    jeopardy_board[category][value][2] = 0
+
+    session['jeopardy'] = jeopardy_board
+
     return render_template("answer_page.html", question=question, answer=answer)
 
 

--- a/templates/answer_page.html
+++ b/templates/answer_page.html
@@ -22,7 +22,7 @@
       </div>
     </div>
     <div>
-      <button class="jeo_button" type="button">Back to Board</button>
+      <a href="{{ url_for('jeopardy_form_post') }}"><button class="jeo_button" type="button">Back to Board</button></a>
     </div>
     {% endblock %}
   </body>

--- a/templates/jeo_board.html
+++ b/templates/jeo_board.html
@@ -16,7 +16,11 @@
       {% for value in increments %}
       <tr>
         {% for i in range(6) %}
-        <td><a href="{{ url_for('answer_page', category=i, value=value)}}"><button class="jeo_button" type="button">${{value}}</button></a></td>
+          {% if board[i][value|string][2]  %}
+            <td><a href="{{ url_for('answer_page', category=i, value=value)}}"><button class="jeo_button" type="button">${{value}}</button></a></td>
+          {% else %}
+          <td></td>
+          {% endif %}
         {% endfor %}
       </tr>
       {% endfor %}


### PR DESCRIPTION
This PR makes it so that question pages are no longer shown on the board after being visited. In order to implement this

1. A new item is added to the list in the list for each question in the jeopardy board data structure. Previously, it was `[question, answer]`, but is now `[question, answer, display]` where a 1 in index 2 means the page has not been visited and should be displayed on the board. This is updated to 0 once the question has been visited.

2. An if statement is added in the creation of the jeopardy board to check this variable for each question. If it is 0, no text or link is displayed in the cell.